### PR TITLE
fix bug for memory leak while adding common files

### DIFF
--- a/kernel/fs/eventpoll.c
+++ b/kernel/fs/eventpoll.c
@@ -1212,11 +1212,11 @@ int ep_insert(struct eventpoll *ep, struct epoll_event *event,
 	if (epi->nwait < 0)
 		goto error_unregister;
 
-	if (!is_file_epoll(tfile)) {
-		error = add_to_tfile_check(&epi->ffd);
-		if (error)
-			goto error_unregister;
-	}
+	//if (!is_file_epoll(tfile)) {
+	//	error = add_to_tfile_check(&epi->ffd);
+	//	if (error)
+	//		goto error_unregister;
+	//}
 
 	/* Add the current item to the list of active epoll hook for this file */
 	spin_lock(&tfile->f_lock);
@@ -1787,7 +1787,9 @@ SYSCALL_DEFINE4(epoll_ctl, int, epfd, int, op, int, fd,
 			}
 		} else
 			error = -EEXIST;
-		clear_tfile_check_list();
+
+		if (full_check)
+			clear_tfile_check_list();
 		break;
 	case EPOLL_CTL_DEL:
 		if (epi) {


### PR DESCRIPTION
Memory leak will be triggerd when calling clear_tfile_check_list without lock.
