### PR TITLE
Spawn the listen socket when invoke the listen system call instead of the epoll

### DIFF
--- a/kernel/fs/fcntl.c
+++ b/kernel/fs/fcntl.c
@@ -92,6 +92,12 @@ SYSCALL_DEFINE3(dup3, unsigned int, oldfd, unsigned int, newfd, int, flags)
 	if (!tofree && FD_ISSET(newfd, fdt->open_fds))
 		goto out_unlock;
 	get_file(file);
+	if (file->sub_file) {
+		get_file(file->sub_file);
+	}
+	if (file->old_file) {
+		get_file(file->old_file);
+	}
 	rcu_assign_pointer(fdt->fd[newfd], file);
 	FD_SET(newfd, fdt->open_fds);
 	if (flags & O_CLOEXEC)
@@ -349,6 +355,12 @@ static long do_fcntl(int fd, unsigned int cmd, unsigned long arg,
 		err = alloc_fd(arg, cmd == F_DUPFD_CLOEXEC ? O_CLOEXEC : 0);
 		if (err >= 0) {
 			get_file(filp);
+			if (filp->sub_file) {
+				get_file(filp->sub_file);
+			}
+			if (filp->old_file) {
+				get_file(filp->old_file);
+			}
 			fd_install(err, filp);
 		}
 		break;

--- a/kernel/fs/file.c
+++ b/kernel/fs/file.c
@@ -368,6 +368,12 @@ struct files_struct *dup_fd(struct files_struct *oldf, int *errorp)
 		struct file *f = *old_fds++;
 		if (f) {
 			get_file(f);
+			if (f->sub_file) {
+				get_file(f->sub_file);
+			}
+			if (f->old_file) {
+				get_file(f->old_file);
+			}
 		} else {
 			/*
 			 * The fd may be claimed in the fd bitmap but not yet

--- a/kernel/net/fastsocket/fastsocket.h
+++ b/kernel/net/fastsocket/fastsocket.h
@@ -22,6 +22,7 @@
 //#define FSOCKET_IOC_EPOLL_CTL _IO(IOC_ID, 0x05)
 #define FSOCKET_IOC_SPAWN_LISTEN _IO(IOC_ID, 0x06)
 #define FSOCKET_IOC_SHUTDOWN_LISTEN _IO(IOC_ID, 0x07)
+#define FSOCKET_IOC_SPAWN_ALL_LISTEN _IO(IOC_ID, 0x08)
 
 #define ALERT 0x00
 #define ERR 0x01
@@ -127,6 +128,7 @@ extern void fsocket_exit(void);
 extern int fsocket_socket(int flags);
 extern int fsocket_listen(struct file *file, int backlog);
 extern int fsocket_spawn(struct file *filp, int fd, int tcpu);
+extern void fscoket_spawn_restore(struct socket *sock, int fd);
 extern int fsocket_accept(struct file *file , struct sockaddr __user *upeer_sockaddr,
 		int __user *upeer_addrlen, int flags);
 extern int fsocket_shutdown_listen(struct file *file, int how);

--- a/library/libsocket.h
+++ b/library/libsocket.h
@@ -20,6 +20,7 @@ typedef unsigned int u32;
 //#define FSOCKET_IOC_EPOLL_CTL _IO(IOC_ID, 0x05)
 #define FSOCKET_IOC_SPAWN_LISTEN _IO(IOC_ID, 0x06)
 #define FSOCKET_IOC_SHUTDOWN_LISTEN _IO(IOC_ID, 0x07)
+#define FSOCKET_IOC_SPAWN_ALL_LISTEN _IO(IOC_ID, 0x08)
 
 struct fsocket_ioctl_arg {
 	u32 fd;


### PR DESCRIPTION
As title, and it also contains other enhancement.
Use the listen hook to spawn socket instead of epoll, it could avoid one unnecessary system call in epoll hook of the original design. 