### PR TITLE
Move nf_ct_free_rcu function to nf_conntrack_core.c to avoid compile …

### DIFF
--- a/kernel/include/net/netfilter/nf_conntrack.h
+++ b/kernel/include/net/netfilter/nf_conntrack.h
@@ -301,16 +301,6 @@ static inline int nf_ct_is_untracked(const struct sk_buff *skb)
 	return (skb->nfct == &nf_conntrack_untracked.ct_general);
 }
 
-extern void nf_mem_pool_free(struct net *net, struct nf_conn *nf);
-static void nf_ct_free_rcu(struct rcu_head *rcu)
-{
-	struct nf_conn *ct = container_of(rcu, struct nf_conn, rcu);
-	struct net *net = nf_ct_net(ct);
-
-	nf_mem_pool_free(net, ct);
-}
-
-
 extern int nf_conntrack_set_hashsize(const char *val, struct kernel_param *kp);
 extern unsigned int nf_conntrack_htable_size;
 extern unsigned int nf_conntrack_max;

--- a/kernel/net/netfilter/nf_conntrack_core.c
+++ b/kernel/net/netfilter/nf_conntrack_core.c
@@ -840,6 +840,15 @@ struct nf_conn *nf_conntrack_alloc(struct net *net,
 }
 EXPORT_SYMBOL_GPL(nf_conntrack_alloc);
 
+extern void nf_mem_pool_free(struct net *net, struct nf_conn *nf);
+static void nf_ct_free_rcu(struct rcu_head *rcu)
+{
+    struct nf_conn *ct = container_of(rcu, struct nf_conn, rcu);
+    struct net *net = nf_ct_net(ct);
+
+    nf_mem_pool_free(net, ct);
+}
+
 void nf_conntrack_free(struct nf_conn *ct)
 {
 	struct net *net = nf_ct_net(ct);


### PR DESCRIPTION
…error without enable conntrack config