### PR TITLE
Update tcp.h

### DIFF
--- a/kernel/include/net/tcp.h
+++ b/kernel/include/net/tcp.h
@@ -111,7 +111,7 @@ extern void tcp_time_wait(struct sock *sk, int state, int timeo);
 				 */
 
 
-#define TCP_TIMEWAIT_LEN (60*HZ) /* how long to wait to destroy TIME-WAIT
+#define TCP_TIMEWAIT_LEN (10*HZ) /* how long to wait to destroy TIME-WAIT
 				  * state, about 60 seconds	*/
 #define TCP_FIN_TIMEOUT	TCP_TIMEWAIT_LEN
                                  /* BSD style FIN_WAIT2 deadlock breaker.


### PR DESCRIPTION
Destroy TIME_WAIT state after 10 seconds instead of 60. Useful for heavy loaded web servers and have no problems with NAT (instead of using net.ipv4.tcp_tw_recycle).
http://www-01.ibm.com/support/knowledgecenter/SSEQTJ_6.1.0/com.ibm.websphere.edge.doc/edge/cp/admingd45.htm
Tested for a year on servers with 24 cores and 128gb ram.